### PR TITLE
Assign profile images to new registrations and populate that in message thumbnails

### DIFF
--- a/api/ably-token-request/index.ts
+++ b/api/ably-token-request/index.ts
@@ -3,24 +3,18 @@ import { Context, HttpRequest } from "@azure/functions";
 import { authorized, ApiRequestContext } from "../common/ApiRequestContext";
 import * as Ably from "ably/promises";
 
-const client = new Ably.Realtime(process.env.ABLY_API_KEY);
+const client = new Ably.Rest(process.env.ABLY_API_KEY);
 
-export default async function (
-  context: Context,
-  req: HttpRequest
-): Promise<void> {
+export default async function (context: Context, req: HttpRequest): Promise<void> {
   await authorized(
     context,
     req,
     async ({ user }: ApiRequestContext) => {
-      const clientId = `${user.id}:${user.username}`;
-
-      const tokenRequestData = await client.auth.createTokenRequest({
-        clientId,
-      });
+      const clientId = `${user.id}:${user.username}:${encodeURIComponent(user.profileImgUrl)}`;
+      const tokenRequestData = await client.auth.createTokenRequest({ clientId });
       context.res = {
         headers: { "content-type": "application/json" },
-        body: JSON.stringify(tokenRequestData),
+        body: JSON.stringify(tokenRequestData)
       };
     },
     true

--- a/api/account-register/index.ts
+++ b/api/account-register/index.ts
@@ -4,10 +4,7 @@ import { AzureFunction, Context, HttpRequest } from "@azure/functions";
 import { UserService } from "../common/services/UserService";
 import { badRequest, badRequestFor, ok } from "../common/http/CommonResults";
 
-const httpTrigger: AzureFunction = async function (
-  context: Context,
-  req: HttpRequest
-): Promise<void> {
+const httpTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
   const data = { ...req.body } as RegistrationForm;
   const validation = new Validator(data, registrationFormRules);
 
@@ -42,7 +39,7 @@ const registrationFormRules = {
   username: "required|min:1",
   firstName: "required|min:1",
   lastName: "required|min:1",
-  password: "required|min:1",
+  password: "required|min:1"
 };
 
 export default httpTrigger;

--- a/api/common/dataaccess/AzureBlobStorageClient.ts
+++ b/api/common/dataaccess/AzureBlobStorageClient.ts
@@ -1,0 +1,18 @@
+import { BlobServiceClient } from "@azure/storage-blob";
+
+const connectionString = process.env.AZURE_STORAGE_CONNECTION_STRING;
+const containerName = process.env.AZURE_STORAGE_CONTAINER_NAME;
+
+const randomProfileImagePicker = () => {
+  const min = 1,
+    max = 9;
+  const profileImageNumber = Math.floor(Math.random() * (max - min + 1)) + min;
+  return `pattern${profileImageNumber}.jpg`;
+};
+
+export const getAzureProfileImgBlobByUrl = async () => {
+  const blobServiceClient = BlobServiceClient.fromConnectionString(connectionString);
+  const containerClient = blobServiceClient.getContainerClient(containerName);
+  const blockBlobClient = containerClient.getBlockBlobClient(randomProfileImagePicker());
+  return blockBlobClient.url;
+};

--- a/api/common/dataaccess/CosmosDbMetadataRepository.ts
+++ b/api/common/dataaccess/CosmosDbMetadataRepository.ts
@@ -12,32 +12,19 @@ export class CosmosDbMetadataRepository implements IMetadataRepository {
     this._client = new CosmosClient({ endpoint, key });
   }
 
-  public async getById<TEntityType extends Entity>(
-    typeName: string,
-    id: string
-  ): Promise<TEntityType> {
+  public async getById<TEntityType extends Entity>(typeName: string, id: string): Promise<TEntityType> {
     const container = await this.getContainer(typeName);
-    const allMatchingItems = await container.items
-      .query(`SELECT * FROM c WHERE c.id = '${id}'`)
-      .fetchAll();
+    const allMatchingItems = await container.items.query(`SELECT * FROM c WHERE c.id = '${id}'`).fetchAll();
     return allMatchingItems[0];
   }
 
-  public async getByProperty<TEntityType extends Entity>(
-    typeName: string,
-    propertyName: string,
-    value: any
-  ): Promise<TEntityType[]> {
+  public async getByProperty<TEntityType extends Entity>(typeName: string, propertyName: string, value: any): Promise<TEntityType[]> {
     const container = await this.getContainer(typeName);
-    const results = await container.items
-      .query(`SELECT * FROM c WHERE c.${propertyName} = '${value}'`)
-      .fetchAll();
+    const results = await container.items.query(`SELECT * FROM c WHERE c.${propertyName} = '${value}'`).fetchAll();
     return results.resources as TEntityType[];
   }
 
-  public async saveOrUpdate<TEntityType extends Entity>(
-    entity: TEntityType
-  ): Promise<void> {
+  public async saveOrUpdate<TEntityType extends Entity>(entity: TEntityType): Promise<void> {
     const container = await this.getContainer(entity.type);
     const result = await container.items.upsert(entity);
 
@@ -48,15 +35,11 @@ export class CosmosDbMetadataRepository implements IMetadataRepository {
 
   public async exists(typeName: string, id: string): Promise<boolean> {
     const container = await this.getContainer(typeName);
-    const countResult = await container.items
-      .query(`SELECT count(1) FROM c WHERE c.id = '${id}'`)
-      .fetchAll();
+    const countResult = await container.items.query(`SELECT count(1) FROM c WHERE c.id = '${id}'`).fetchAll();
     return countResult[0] > 0;
   }
 
-  public async getAll<TEntityType extends Entity>(
-    typeName: string
-  ): Promise<TEntityType[]> {
+  public async getAll<TEntityType extends Entity>(typeName: string): Promise<TEntityType[]> {
     const container = await this.getContainer(typeName);
     const results = await container.items.readAll().fetchAll();
     return results.resources as TEntityType[];

--- a/api/common/metadata/User.ts
+++ b/api/common/metadata/User.ts
@@ -8,6 +8,7 @@ export interface IUser extends Entity {
   lastName: string;
   passwordHash: string;
   oauthSub: string;
+  profileImgUrl: string;
 }
 
 export class User implements IUser, Entity {
@@ -19,14 +20,13 @@ export class User implements IUser, Entity {
   public lastName: string;
   public passwordHash: string;
   public oauthSub: string;
+  public profileImgUrl: string;
 
   constructor() {
     this.type = "User";
   }
 
-  public async passwordMatches(
-    suppliedClearTextPassword: string
-  ): Promise<boolean> {
+  public async passwordMatches(suppliedClearTextPassword: string): Promise<boolean> {
     return await bcrypt.compare(suppliedClearTextPassword, this.passwordHash);
   }
 
@@ -52,13 +52,10 @@ export class User implements IUser, Entity {
   }
 
   private static createId(): string {
-    return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(
-      /[xy]/g,
-      function (c) {
-        var r = (Math.random() * 16) | 0,
-          v = c == "x" ? r : (r & 0x3) | 0x8;
-        return v.toString(16);
-      }
-    );
+    return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
+      var r = (Math.random() * 16) | 0,
+        v = c == "x" ? r : (r & 0x3) | 0x8;
+      return v.toString(16);
+    });
   }
 }

--- a/api/common/services/UserService.ts
+++ b/api/common/services/UserService.ts
@@ -1,7 +1,7 @@
 import { CosmosDbMetadataRepository } from "../dataaccess/CosmosDbMetadataRepository";
 import { JwtGenerator } from "../JwtGenerator";
 import { User } from "../metadata/User";
-import { getAzureProfileImgBlobByUrl } from "../dataaccess/AzureBlobStorageData";
+import { getAzureProfileImgBlobByUrl } from "../dataaccess/AzureBlobStorageClient";
 
 export type LoginMetadata = {
   username: string;

--- a/api/oauth-login/index.ts
+++ b/api/oauth-login/index.ts
@@ -4,14 +4,11 @@ import { AuthenticationClient } from "auth0";
 import { UserService } from "../common/services/UserService";
 import { ok, forbidden } from "../common/http/CommonResults";
 
-const httpTrigger: AzureFunction = async function (
-  context: Context,
-  req: HttpRequest
-): Promise<void> {
+const httpTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
   var auth0 = new AuthenticationClient({
     domain: process.env.AUTH0_DOMAIN,
     client_id: process.env.AUTH0_CLIENTID,
-    redirect_uri: process.env.AUTH0_REDIRECT_URI,
+    redirect_uri: process.env.AUTH0_REDIRECT_URI
   });
 
   const userService = new UserService();
@@ -19,9 +16,7 @@ const httpTrigger: AzureFunction = async function (
   try {
     const data = await auth0.getProfile(req.body.token);
 
-    const { exists, user } = await userService.getUserByOAuthSubscription(
-      data.sub
-    );
+    const { exists, user } = await userService.getUserByOAuthSubscription(data.sub);
 
     if (exists) {
       const metadata = userService.generateLoginMetadataFor(user);

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -18,12 +18,76 @@
         "tslib": "^2.0.0"
       }
     },
+    "@azure/core-asynciterator-polyfill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.0.tgz",
+      "integrity": "sha512-kmv8CGrPfN9SwMwrkiBK9VTQYxdFQEGe0BmQk+M8io56P9KNzpAxcWE/1fxJj7uouwN4kXF0BHW8DNlgx+wtCg=="
+    },
     "@azure/core-auth": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.3.2.tgz",
       "integrity": "sha512-7CU6DmCHIZp5ZPiZ9r3J17lTKMmYsm/zGvNkjArQwPkrLlZ1TZ+EUYfGgh2X31OLMVAQCTJZW4cXHJi02EbJnA==",
       "requires": {
         "@azure/abort-controller": "^1.0.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "@azure/core-http": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-2.2.2.tgz",
+      "integrity": "sha512-V1DdoO9V/sFimKpdWoNBgsE+QUjQgpXYnxrTdUp5RyhsTJjvEVn/HKmTQXIHuLUUo6IyIWj+B+Dg4VaXse9dIA==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-asynciterator-polyfill": "^1.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-tracing": "1.0.0-preview.13",
+        "@azure/logger": "^1.0.0",
+        "@types/node-fetch": "^2.5.0",
+        "@types/tunnel": "^0.0.3",
+        "form-data": "^4.0.0",
+        "node-fetch": "^2.6.0",
+        "process": "^0.11.10",
+        "tough-cookie": "^4.0.0",
+        "tslib": "^2.2.0",
+        "tunnel": "^0.0.6",
+        "uuid": "^8.3.0",
+        "xml2js": "^0.4.19"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
+      }
+    },
+    "@azure/core-lro": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.2.1.tgz",
+      "integrity": "sha512-HE6PBl+mlKa0eBsLwusHqAqjLc5n9ByxeDo3Hz4kF3B1hqHvRkBr4oMgoT6tX7Hc3q97KfDctDUon7EhvoeHPA==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-tracing": "1.0.0-preview.13",
+        "@azure/logger": "^1.0.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "@azure/core-paging": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.2.0.tgz",
+      "integrity": "sha512-ZX1bCjm/MjKPCN6kQD/9GJErYSoKA8YWp6YWoo5EIzcTWlSBLXu3gNaBTUl8usGl+UShiKo7b4Gdy1NSTIlpZg==",
+      "requires": {
+        "@azure/core-asynciterator-polyfill": "^1.0.0",
         "tslib": "^2.2.0"
       }
     },
@@ -105,6 +169,21 @@
       "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.3.tgz",
       "integrity": "sha512-aK4s3Xxjrx3daZr3VylxejK3vG5ExXck5WOHDJ8in/k9AqlfIyFMMT1uG7u8mNjX+QRILTIn0/Xgschfh/dQ9g==",
       "requires": {
+        "tslib": "^2.2.0"
+      }
+    },
+    "@azure/storage-blob": {
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.8.0.tgz",
+      "integrity": "sha512-c8+Wz19xauW0bGkTCoqZH4dYfbtBniPiGiRQOn1ca6G5jsjr4azwaTk9gwjVY8r3vY2Taf95eivLzipfIfiS4A==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-http": "^2.0.0",
+        "@azure/core-lro": "^2.2.0",
+        "@azure/core-paging": "^1.1.1",
+        "@azure/core-tracing": "1.0.0-preview.13",
+        "@azure/logger": "^1.0.0",
+        "events": "^3.0.0",
         "tslib": "^2.2.0"
       }
     },
@@ -1191,6 +1270,15 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
       "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
     },
+    "@types/node-fetch": {
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.12.tgz",
+      "integrity": "sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==",
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
     "@types/prettier": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.1.tgz",
@@ -1221,6 +1309,14 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "@types/tunnel": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.3.tgz",
+      "integrity": "sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/yargs": {
       "version": "16.0.4",
@@ -2178,6 +2274,11 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
+    },
+    "events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
     "execa": {
       "version": "5.1.1",
@@ -4982,6 +5083,11 @@
       "resolved": "https://registry.npmjs.org/priorityqueuejs/-/priorityqueuejs-1.0.0.tgz",
       "integrity": "sha1-LuTyPCVgkT4IwHzlzN1t498sWvg="
     },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+    },
     "prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -5169,6 +5275,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "saxes": {
       "version": "5.0.1",
@@ -5621,7 +5732,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
       "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
-      "dev": true,
       "requires": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -5668,6 +5778,11 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -5738,8 +5853,7 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "upper-case": {
       "version": "1.1.3",
@@ -6015,6 +6129,20 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/api/package.json
+++ b/api/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@azure/cosmos": "^3.14.1",
+    "@azure/storage-blob": "^12.8.0",
     "ably": "^1.2.14",
     "auth0": "^2.37.0",
     "bcrypt": "^5.0.1",

--- a/app/src/components/Chat/ChatHistory.jsx
+++ b/app/src/components/Chat/ChatHistory.jsx
@@ -3,8 +3,10 @@ import React from "react";
 export const ChatHistory = ({ history }) => {
   const messageElements = history.map((item, index) => {
     const user = item.clientId.split(":")[1];
+    const profileImgUrl = decodeURIComponent(item.clientId.split(":")[2]);
     return (
       <li key={index} className="message">
+        <img className="message-thumbnail" src={profileImgUrl}></img>
         <span className="sender">{user}</span>
         <span className="text">{item.data.text}</span>
       </li>

--- a/app/src/components/Chat/ChatHistory.jsx
+++ b/app/src/components/Chat/ChatHistory.jsx
@@ -7,7 +7,7 @@ export const ChatHistory = ({ history }) => {
     const messageTime = new Date(item.timestamp).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
     return (
       <li key={index} className="message">
-        <img className="message-thumbnail" src={profileImgUrl}></img>
+        <img className="message-thumbnail" src={profileImgUrl} alt={user}/>
         <span className="sender">
           {user}
           <span className="time">{messageTime}</span>

--- a/app/src/components/Chat/chat.css
+++ b/app/src/components/Chat/chat.css
@@ -45,13 +45,12 @@
 }
 
 .message-thumbnail {
-  content: "";
   position: absolute;
   left: 0;
   display: block;
   width: 3rem;
   height: 3rem;
-  background-color: black;
+  background-color: var(--primary);
 }
 
 .sender {
@@ -62,9 +61,9 @@
 .time {
   float: right;
   margin-left: 1rem;
-  font-size: .8rem;
+  font-size: 0.8rem;
   font-weight: normal;
-  color: var(--secondary)
+  color: var(--secondary);
 }
 
 .end-message {
@@ -79,7 +78,7 @@
 .members {
   display: block;
   font-weight: normal;
-  font-size: .8rem;
+  font-size: 0.8rem;
 }
 
 @media screen and (max-width: 799px) {
@@ -88,10 +87,10 @@
     top: 0;
     height: calc(100vh - 3rem - 1px);
     background-color: var(--negative);
-    transition: all .2s ease-in-out;
+    transition: all 0.2s ease-in-out;
   }
 
-  .channel-view .chat{
+  .channel-view .chat {
     transform: translateX(100%);
   }
 

--- a/app/src/components/Chat/chat.css
+++ b/app/src/components/Chat/chat.css
@@ -43,7 +43,7 @@
   list-style: none;
 }
 
-.message::before {
+.message-thumbnail {
   content: "";
   position: absolute;
   left: 0;

--- a/app/src/components/Chat/index.jsx
+++ b/app/src/components/Chat/index.jsx
@@ -41,7 +41,7 @@ const Chat = ({ currentChannel, onChatExit }) => {
         </button>
         <h2>
           {currentChannel}
-          <span class="members">1 member</span>
+          <span className="members">1 member</span>
         </h2>
       </header>
       <ul className="messages">

--- a/app/src/sdk/BffApiClient.js
+++ b/app/src/sdk/BffApiClient.js
@@ -5,9 +5,7 @@ export class BffApiClient {
   }
 
   async fetch(input, init) {
-    init.headers = this._jwtToken
-      ? { ...init.headers, jwt: this._jwtToken }
-      : init.headers;
+    init.headers = this._jwtToken ? { ...init.headers, jwt: this._jwtToken } : init.headers;
     const func = this._fetchFunc || fetch;
     return await func(input, init);
   }


### PR DESCRIPTION
Note - This PR inevitably includes some formatting changes in some of the files.

Key things:

- I'm using Azure storage blobs to store actual images
- The blob container's access is set to anonymous as the plan is to share around URLs and not the images themselves which means the URLs need to be accessed from the client-side.
- I have an Azure blob client in the `dataaccess` folder which gets the URL of a randomly picked image from the 9 available. This URL is attached to the user in `createUser` that is part of the UserService. This method is shared between register natively and registers via auth0, so we are good on that front. This means it also correctly gets stored in CosmosDB along with other user details.
- Currently, the username of a user is attached as part of the Ably client id via token params, so I've added an encoded profile image link assigned to that user as part of that as well. I think we could do something better here but haven't given it much thought yet
- In `ChatHistory` component, the username was being retrieved from the`clientid`. So I've done the same for `profileimgurl` (URL decoded) now. What was previously a black block is now filled with the image retrieved from that url.