### PR TITLE
Add error handler for proxy use from app to api

### DIFF
--- a/snowpack.config.mjs
+++ b/snowpack.config.mjs
@@ -16,7 +16,9 @@ export default {
     {
       src: "/api/.*",
       dest: (req, res) => {
-        return proxy.web(req, res, { hostname: "localhost", port: 7071 });
+        return proxy.web(req, res, { hostname: "localhost", port: 7071 }, (err) => {
+          console.log(err);
+        });
       }
     },
     {


### PR DESCRIPTION
Without an error handler the app would crash whenever there was a connection issue to the api or a non-responsive api.