### PR TITLE
Switch role validation from db check to from JWT contents

### DIFF
--- a/api/common/JwtGenerator.ts
+++ b/api/common/JwtGenerator.ts
@@ -23,12 +23,13 @@ export class JwtGenerator {
     return new JwtGenerator(signingKey);
   }
 
-  generate(userId: string, extraClaims?: any) {
+  generate(userId: string, roleName: string, extraClaims?: any) {
     const claims = {
       iss: "http://ffschat.ably.dev/", // The URL of your service
       sub: `users/${userId}`, // The UID of the user in your system
       scope: "self, users",
       userId,
+      roleName,
       ...(extraClaims || {})
     };
 

--- a/api/common/metadata/User.ts
+++ b/api/common/metadata/User.ts
@@ -30,6 +30,7 @@ export class User implements IUser, Entity {
 
   constructor() {
     this.type = "User";
+    this.roleName = "default";
   }
 
   public async passwordMatches(suppliedClearTextPassword: string): Promise<boolean> {

--- a/api/common/services/UserService.ts
+++ b/api/common/services/UserService.ts
@@ -60,7 +60,7 @@ export class UserService {
 
     const roleService = new RoleService();
     const result = await roleService.getRoleByName(user.roleName);
-    console.log(result);
+
     const { exists: roleExists, role } = result;
 
     if (!roleExists) {
@@ -85,8 +85,7 @@ export class UserService {
     const userProfileImageLargeUrl = await this.getProfileImage(request.email, 600, request.oauthPicture);
     const requestWithProfileImg = {
       ...request,
-      profileImgSmallUrl: userProfileImageSmallUrl,
-      profileImgLargeUrl: userProfileImageLargeUrl,
+      profileImgUrl: userProfileImageUrl,
       roleName: "normal"
     };
     const user = User.fromJSON(requestWithProfileImg);
@@ -98,7 +97,7 @@ export class UserService {
     token: string;
     userDetails: LoginMetadata;
   } {
-    const token = this._jwtValidator.generate(user.id);
+    const token = this._jwtValidator.generate(user.id, user.roleName);
     const userDetails = {
       username: user.username,
       firstName: user.firstName,

--- a/api/common/services/UserService.ts
+++ b/api/common/services/UserService.ts
@@ -85,7 +85,8 @@ export class UserService {
     const userProfileImageLargeUrl = await this.getProfileImage(request.email, 600, request.oauthPicture);
     const requestWithProfileImg = {
       ...request,
-      profileImgUrl: userProfileImageUrl,
+      profileImgSmallUrl: userProfileImageSmallUrl,
+      profileImgLargeUrl: userProfileImageLargeUrl,
       roleName: "normal"
     };
     const user = User.fromJSON(requestWithProfileImg);


### PR DESCRIPTION
We were previously checking the database each time we needed to validate if a user had the correct role to perform an action for an endpoint. This PR avoids that by instead attaching the roleName to the JWT a client will have, so that we can instead check the JWT's roleName field to ensure it matches.

This should eventually be swapped probably to have the JWT contain the permissions over just the roleName as that'll be more relevant, but that is for a later PR once we define and create permissions for roles.